### PR TITLE
Subfolder and olignore support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ wheels/
 .installed.cfg
 *.egg
 MANIFEST
+pip-wheel-metadata/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,7 @@ venv.bak/
 
 # vscode
 .vscode
+.DS_Store
 
 # dev testing
 setup.py

--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,11 @@ venv.bak/
 
 #PyCharm
 .idea/
+
+# vscode
+.vscode
+
+# dev testing
+setup.py
+test*
+.olignore

--- a/.gitignore
+++ b/.gitignore
@@ -112,4 +112,5 @@ venv.bak/
 # dev testing
 setup.py
 test*
+.olauth
 .olignore

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Overleaf-Sync 1.0.2
+# Overleaf-Sync 1.0.3
 
 ### Easy Overleaf Two-Way Synchronization
 
@@ -31,7 +31,7 @@ That's it!
 - Execute the script from that folder (`test`)
 
 ### Usage
-#### Login 
+#### Login
 ```
 moritz@github:~/test$ ols login [-u/--username -p/--pasword --path]
 Username: <overleaf username>
@@ -43,10 +43,10 @@ You can either specify your username and/or password on the command line or you 
 
 ### Syncing
 ```
-moritz@github:~/test$ ols [-s/--sync -l/--local-only -r/--remote-only --store-path -p/--path]
+moritz@github:~/test$ ols [-l/--local-only -r/--remote-only --store-path -p/--path --olignore]
 ```
 
-Just calling `ols` will two-way sync your project. When there are changes both locally and remotely you will be asked which file to keep. Using the `-l` or `-r` option you can specify to either sync local project files to Overleaf only or Overleaf files to local ones only respectively. The option `--store-path` specifies the path of the cookie file created by the `login` command. If you did not change its path you do not need to specify this argument. The `-p/--path` option allows you to specify a different sync folder than the one you're calling `ols` from.
+Just calling `ols` will two-way sync your project. When there are changes both locally and remotely you will be asked which file to keep. Using the `-l` or `-r` option you can specify to either sync local project files to Overleaf only or Overleaf files to local ones only respectively. The option `--store-path` specifies the path of the cookie file created by the `login` command. If you did not change its path you do not need to specify this argument. The `-p/--path` option allows you to specify a different sync folder than the one you're calling `ols` from. The `--olignore` option allows you to specifify the path of `.olignore` file which works exactly like `.gitignore`.
 
 Sample Output:
 
@@ -71,6 +71,7 @@ other-report.tex does not exist on local. Creating file.
 
 ## Known Bugs
 - When modifying a file on Overleaf and immediately syncing afterwards, the tool might not detect the changes. Please allow 1-2 minutes after modifying a file on Overleaf before syncing it to your local computer.
+- When syncing from local to remote, files (including the ones in sub-directories) will all be synced to the root directory under Overleaf project (i.e., if local files under different folder share a same name, only the last synced file will be on Overleaf).
 
 ## Disclaimer
 THE AUTHOR OF THIS SOFTWARE AND THIS SOFTWARE IS NOT ENDORSED BY, DIRECTLY AFFILIATED WITH, MAINTAINED, AUTHORIZED, OR SPONSORED BY OVERLEAF OR WRITELATEX LIMITED. ALL PRODUCT AND COMPANY NAMES ARE THE REGISTERED TRADEMARKS OF THEIR ORIGINAL OWNERS. THE USE OF ANY TRADE NAME OR TRADEMARK IS FOR IDENTIFICATION AND REFERENCE PURPOSES ONLY AND DOES NOT IMPLY ANY ASSOCIATION WITH THE TRADEMARK HOLDER OF THEIR PRODUCT BRAND.

--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ You can either specify your username and/or password on the command line or you 
 
 ### Syncing
 ```
-moritz@github:~/test$ ols [-l/--local-only -r/--remote-only --store-path -p/--path --olignore]
+moritz@github:~/test$ ols [-l/--local-only -r/--remote-only --store-path -p/--path -i/--olignore]
 ```
 
-Just calling `ols` will two-way sync your project. When there are changes both locally and remotely you will be asked which file to keep. Using the `-l` or `-r` option you can specify to either sync local project files to Overleaf only or Overleaf files to local ones only respectively. The option `--store-path` specifies the path of the cookie file created by the `login` command. If you did not change its path you do not need to specify this argument. The `-p/--path` option allows you to specify a different sync folder than the one you're calling `ols` from. The `--olignore` option allows you to specifify the path of `.olignore` file which works exactly like `.gitignore`.
+Just calling `ols` will two-way sync your project. When there are changes both locally and remotely you will be asked which file to keep. Using the `-l` or `-r` option you can specify to either sync local project files to Overleaf only or Overleaf files to local ones only respectively. The option `--store-path` specifies the path of the cookie file created by the `login` command. If you did not change its path you do not need to specify this argument. The `-p/--path` option allows you to specify a different sync folder than the one you're calling `ols` from. The `-i/--olignore` option allows you to specify the path of `.olignore` file which works exactly like `.gitignore`.
 
 Sample Output:
 

--- a/olsync/olsync.py
+++ b/olsync/olsync.py
@@ -29,7 +29,7 @@ import fnmatch
               help="Relative path to load the persisted Overleaf cookie.")
 @click.option('-p', '--path', 'sync_path', default=".", type=click.Path(exists=True),
               help="Path of the project to sync.")
-@click.option('--olignore', 'olignore_path', default=".olignore", type=click.Path(exists=False),
+@click.option('-i', '--olignore', 'olignore_path', default=".olignore", type=click.Path(exists=True),
               help="Relative path of the .olignore file (works when syncing from local to remote).")
 @click.pass_context
 def main(ctx, local, remote, cookie_path, sync_path, olignore_path):
@@ -47,8 +47,10 @@ def main(ctx, local, remote, cookie_path, sync_path, olignore_path):
             lambda: overleaf_client.get_project(
                 os.path.basename(os.path.join(sync_path, os.getcwd()))),
             "Querying project", "Project queried successfully.", "Project could not be queried.")
-        zip_file = execute_action(lambda: zipfile.ZipFile(io.BytesIO
-                                                          (overleaf_client.download_project(project["id"]))), "Downloading project", "Project downloaded successfully.", "Project could not be downloaded.")
+        zip_file = execute_action(lambda: zipfile.ZipFile(io.BytesIO(overleaf_client.download_project(project["id"]))),
+                                  "Downloading project",
+                                  "Project downloaded successfully.",
+                                  "Project could not be downloaded.")
 
         sync = not (local or remote)
 
@@ -136,8 +138,8 @@ def sync_func(files_from, create_file_at_to, from_exists_in_to, from_equal_to_to
                 # non-empty _dir
                 os.makedirs(_dir)
 
-            # `name` itself is not dir
-            if not os.path.isdir(name):
+            # `name` itself is not a directory
+            if os.path.isfile(name):
                 create_file_at_to(name)
 
         click.echo("")


### PR DESCRIPTION
- **New** Add `--olignore` option for `ols` command. Fully support function like .gitignore.
- **New** Add subfolder syncing support. When syncing from remote to local, every file will be synced as its original location in file tree. Empty folder will NOT be synced.
- **Fix** JSON bug in olsync/olclient:upload_file "JSNO object must be str, not 'bytes'".
- **TODO** Know issue: when syncing from local to remote, every file in sub-directory will be synced to remote, but only to the project root. TODO: mechanism to support `makedirs` on remote end and id the folder.