### PR TITLE
Add dependency for socketIO-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Overleaf-Sync 1.1.0
+# Overleaf-Sync 1.1.1
 
 ### Easy Overleaf Two-Way Synchronization
 

--- a/olsync/__init__.py
+++ b/olsync/__init__.py
@@ -1,3 +1,3 @@
 """Overleaf Two-Way Sync Tool"""
 
-__version__ = '1.1.0'
+__version__ = '1.1.1'

--- a/olsync/olclient.py
+++ b/olsync/olclient.py
@@ -6,7 +6,7 @@
 # Description: Overleaf API Wrapper
 # Author: Moritz Glöckl
 # License: MIT
-# Version: 1.1.0
+# Version: 1.1.1
 ##################################################
 
 import requests as reqs

--- a/olsync/olsync.py
+++ b/olsync/olsync.py
@@ -6,7 +6,7 @@
 # Description: Overleaf Two-Way Sync
 # Author: Moritz Glöckl
 # License: MIT
-# Version: 1.1.0
+# Version: 1.1.1
 ##################################################
 
 import click

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ author-email = "moritzgloeckl@users.noreply.github.com"
 home-page = "https://github.com/moritzgloeckl/overleaf-sync"
 classifiers = ["License :: OSI Approved :: MIT License", "Intended Audience :: Science/Research", "Programming Language :: Python :: 3"]
 requires-python = ">=3"
-requires = ["requests", "beautifulsoup4", "yaspin", "python-dateutil", "click"]
+requires = ["requests", "beautifulsoup4", "yaspin", "python-dateutil", "click", "socketIO-client == 0.5.7.2"]
 keywords = "overleaf sync latex tex"
 
 [tool.flit.scripts]


### PR DESCRIPTION
This adds the required dependency for `socketIO-client` 0.5.7.2 and bumps the version to 1.1.1