### PR TITLE
Support for Community Edition

### DIFF
--- a/olsync/olclient.py
+++ b/olsync/olclient.py
@@ -57,12 +57,13 @@ class OverleafClient(object):
 
         # On a successful authentication the Overleaf API returns a new authenticated cookie.
         # If the cookie is different than the cookie of the GET request the authentication was successful
-        if post_login.status_code == 200 and get_login.cookies["overleaf_session2"] != post_login.cookies[
-            "overleaf_session2"]:
+        if post_login.status_code == 200 and get_login.cookies["sharelatex.sid"] != post_login.cookies[
+            "sharelatex.sid"]:
+
             self._cookie = post_login.cookies
 
             # Enrich cookie with gke-route cookie from GET request above
-            self._cookie['gke-route'] = get_login.cookies['gke-route']
+            #self._cookie['gke-route'] = get_login.cookies['gke-route']
 
             return {"cookie": self._cookie, "csrf": self._csrf}
 
@@ -144,10 +145,9 @@ class OverleafClient(object):
             project_infos = project_infos_dict
 
         # Convert cookie from CookieJar to string
-        cookie = "gke-route={}; overleaf_session2={}" \
+        cookie = "sharelatex.sid={}" \
             .format(
-                reqs.utils.dict_from_cookiejar(self._cookie)["gke-route"],
-                reqs.utils.dict_from_cookiejar(self._cookie)["overleaf_session2"]
+                reqs.utils.dict_from_cookiejar(self._cookie)["sharelatex.sid"]
             )
 
         # Connect to Overleaf Socket.IO, send a time parameter and the cookies

--- a/olsync/olsync.py
+++ b/olsync/olsync.py
@@ -48,7 +48,21 @@ def main(ctx, local, remote, cookie_path, sync_path, olignore_path):
         with open(cookie_path, 'rb') as f:
             store = pickle.load(f)
 
-        overleaf_client = OverleafClient(store["cookie"], store["csrf"])
+        #Read .olce file for URL to local installation of Overleaf/Sharelatex
+        olce_file = os.path.join(sync_path, ".olce")
+        click.echo("=" * 40)
+        ce_url = None
+        if not os.path.isfile(olce_file):
+            click.echo("\nNotice: .olce file does not exist, will sync with overleaf.com.")
+        else:
+
+            with open(olce_file, 'r') as f:
+                ce_url = f.readline()
+                f.close()
+
+            click.echo("\n.olce: using %s as CE server" % ce_url)
+
+        overleaf_client = OverleafClient(store["cookie"], store["csrf"], ce_url)
 
         project = execute_action(
             lambda: overleaf_client.get_project(

--- a/olsync/olsync.py
+++ b/olsync/olsync.py
@@ -48,19 +48,7 @@ def main(ctx, local, remote, cookie_path, sync_path, olignore_path):
         with open(cookie_path, 'rb') as f:
             store = pickle.load(f)
 
-        #Read .olce file for URL to local installation of Overleaf/Sharelatex
-        olce_file = os.path.join(sync_path, ".olce")
-        click.echo("=" * 40)
-        ce_url = None
-        if not os.path.isfile(olce_file):
-            click.echo("\nNotice: .olce file does not exist, will sync with overleaf.com.")
-        else:
-
-            with open(olce_file, 'r') as f:
-                ce_url = f.readline()
-                f.close()
-
-            click.echo("\n.olce: using %s as CE server" % ce_url)
+        ce_url = olceChecker(sync_path)
 
         overleaf_client = OverleafClient(store["cookie"], store["csrf"], ce_url)
 
@@ -133,7 +121,7 @@ def login(username, password, cookie_path):
 
 
 def login_handler(username, password, path):
-    overleaf_client = OverleafClient()
+    overleaf_client = OverleafClient(None, None, olceChecker())
     store = overleaf_client.login(username, password)
     if store is None:
         return False
@@ -247,6 +235,24 @@ def olignore_keep_list(sync_path, olignore_path):
     keep_list = [item for item in keep_list if not os.path.isdir(item)]
     return keep_list
 
+def olceChecker(sync_path = ""):
+
+    # Read .olce file for URL to local installation of Overleaf/Sharelatex
+    olce_file = os.path.join(sync_path, ".olce")
+
+    click.echo("=" * 40)
+    ce_url = None
+    if not os.path.isfile(olce_file):
+        click.echo("\nNotice: .olce file does not exist, will sync with overleaf.com.")
+    else:
+
+        with open(olce_file, 'r') as f:
+            ce_url = f.readline()
+            f.close()
+
+        click.echo("\n.olce: using %s as CE server" % ce_url)
+
+    return ce_url
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Support for CE edition is added and can be used by placing a .olce file in the directory, containing the target url without a closing slash. When the file is missing sync will be done with overleaf.com. I tested it with overleaf.com and my local install with some test syncs. Further is appreciated.