### PR TITLE
Allow specifying project name, several other improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Overleaf-Sync 1.1.1
+# Overleaf-Sync 1.1.2
 
 ### Easy Overleaf Two-Way Synchronization
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This tool provides an easy way to synchronize Overleaf projects from and to your
 - Sync your remotely modified `.tex` (and other) files to computer
 - Works with free Overleaf account
 - No Git or Dropbox required
-- Does not steal or store your login credentials (works with a persisted cookie, [check yourself](https://github.com/moritzgloeckl/overleaf-sync/blob/master/olsync/olclient.py#40))
+- Does not steal or store your login credentials (works with a persisted cookie, [check yourself](https://github.com/moritzgloeckl/overleaf-sync/blob/master/olsync/olclient.py#L40))
 
 ## How To Use
 ### Install

--- a/olsync/__init__.py
+++ b/olsync/__init__.py
@@ -1,3 +1,3 @@
 """Overleaf Two-Way Sync Tool"""
 
-__version__ = '1.1.1'
+__version__ = '1.1.2'

--- a/olsync/olclient.py
+++ b/olsync/olclient.py
@@ -6,7 +6,7 @@
 # Description: Overleaf API Wrapper
 # Author: Moritz Glöckl
 # License: MIT
-# Version: 1.1.1
+# Version: 1.1.2
 ##################################################
 
 import requests as reqs

--- a/olsync/olclient.py
+++ b/olsync/olclient.py
@@ -33,6 +33,14 @@ class OverleafClient(object):
     uploading a file to a project.
     """
 
+    @staticmethod
+    def filter_projects(json_content, more_attrs=None):
+        more_attrs = more_attrs or {}
+        for p in json_content.get("projects", []):
+            if not p.get("archived") and not p.get("trashed"):
+                if all(p.get(k) == v for k, v in more_attrs.items()):
+                    yield p
+
     def __init__(self, cookie=None, csrf=None):
         self._cookie = cookie  # Store the cookie for authenticated requests
         self._csrf = csrf  # Store the CSRF token since it is needed for some requests
@@ -68,13 +76,13 @@ class OverleafClient(object):
 
     def all_projects(self):
         """
-        Get all of a user's active projects (= not archived)
+        Get all of a user's active projects (= not archived and not trashed)
         Returns: List of project objects
         """
         projects_page = reqs.get(PROJECT_URL, cookies=self._cookie)
         json_content = json.loads(
             BeautifulSoup(projects_page.content, 'html.parser').find('script', {'id': 'data'}).contents[0])
-        return list(filter(lambda x: not x.get("archived"), json_content.get("projects")))
+        return list(OverleafClient.filter_projects(json_content))
 
     def get_project(self, project_name):
         """
@@ -86,9 +94,7 @@ class OverleafClient(object):
         projects_page = reqs.get(PROJECT_URL, cookies=self._cookie)
         json_content = json.loads(
             BeautifulSoup(projects_page.content, 'html.parser').find('script', {'id': 'data'}).contents[0])
-        return next(
-            filter(lambda x: not x.get("archived") and x.get("name") == project_name, json_content.get("projects")),
-            None)
+        return next(OverleafClient.filter_projects(json_content, {"name": project_name}), None)
 
     def download_project(self, project_id):
         """

--- a/olsync/olsync.py
+++ b/olsync/olsync.py
@@ -6,7 +6,7 @@
 # Description: Overleaf Two-Way Sync
 # Author: Moritz Glöckl
 # License: MIT
-# Version: 1.1.1
+# Version: 1.1.2
 ##################################################
 
 import click


### PR DESCRIPTION
This PR adds support for project names. Project names can be specified via `-n/--name`. Also includes several other improvements as well as bumping the version to `1.1.2`.