### PR TITLE
Fixed login issue

### DIFF
--- a/olsync/__init__.py
+++ b/olsync/__init__.py
@@ -1,3 +1,3 @@
 """Overleaf Two-Way Sync Tool"""
 
-__version__ = '1.1.3'
+__version__ = '1.1.4'

--- a/olsync/olclient.py
+++ b/olsync/olclient.py
@@ -6,7 +6,7 @@
 # Description: Overleaf API Wrapper
 # Author: Moritz Glöckl
 # License: MIT
-# Version: 1.1.3
+# Version: 1.1.4
 ##################################################
 
 import requests as reqs

--- a/olsync/olclient.py
+++ b/olsync/olclient.py
@@ -69,8 +69,8 @@ class OverleafClient(object):
             "overleaf_session2"]:
             self._cookie = post_login.cookies
 
-            # Enrich cookie with gke-route cookie from GET request above
-            self._cookie['gke-route'] = get_login.cookies['gke-route']
+            # Enrich cookie with GCLB cookie from GET request above
+            self._cookie['GCLB'] = get_login.cookies['GCLB']
 
             # CSRF changes after making the login request, new CSRF token will be on the projects page
             projects_page = reqs.get(PROJECT_URL, cookies=self._cookie)
@@ -159,9 +159,9 @@ class OverleafClient(object):
             project_infos = project_infos_dict
 
         # Convert cookie from CookieJar to string
-        cookie = "gke-route={}; overleaf_session2={}" \
+        cookie = "GCLB={}; overleaf_session2={}" \
             .format(
-            reqs.utils.dict_from_cookiejar(self._cookie)["gke-route"],
+            reqs.utils.dict_from_cookiejar(self._cookie)["GCLB"],
             reqs.utils.dict_from_cookiejar(self._cookie)["overleaf_session2"]
         )
 

--- a/olsync/olsync.py
+++ b/olsync/olsync.py
@@ -6,7 +6,7 @@
 # Description: Overleaf Two-Way Sync
 # Author: Moritz Glöckl
 # License: MIT
-# Version: 1.1.3
+# Version: 1.1.4
 ##################################################
 
 import click


### PR DESCRIPTION
There's a new `GCLB` cookie which replaces the `gke-route` cookie. This PR adapts for these changes, version has been bumped to `1.1.4`