### PR TITLE
Updated login flow to reflect Overleaf changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,40 +12,43 @@ This tool provides an easy way to synchronize Overleaf projects from and to your
 - Sync your remotely modified `.tex` (and other) files to computer
 - Works with free Overleaf account
 - No Git or Dropbox required
-- Does not steal or store your login credentials (works with a persisted cookie, [check yourself](https://github.com/moritzgloeckl/overleaf-sync/blob/master/olsync/olclient.py#L55))
+- Does not steal or store your login credentials (works with a persisted cookie, logging in is done on the original Overleaf website)
 
 ## How To Use
 ### Install
 The package is available via [PyPI](https://pypi.org/project/overleaf-sync/). Just run:
 
 ```
-moritz@github:~/test$ pip install overleaf-sync
+moritz@github:~/test$ pip3 install overleaf-sync
 ```
 
-That's it!
+That's it! Depending on your local Python installation, you might need to use `pip` instead of `pip3`.
 
 ### Prerequisites
-- Create your project on [Overleaf](https://www.overleaf.com/project), for example `test`. The tool is not able to create projects (yet).
-- Create a folder with the same name as the project (`test`) on your computer
-- Execute the script from that folder (`test`)
+- Create your project on [Overleaf](https://www.overleaf.com/project), for example a project named `test`. Overleaf-sync is not able to create projects (yet).
+- Create a folder, preferably with the same name as the project (`test`) on your computer.
+- Execute the script from that folder (`test`).
+- If you do not specify the project name, overleaf-sync uses the current folder's name as the project name.
 
 ### Usage
 #### Login
 ```
-moritz@github:~/test$ ols login [-u/--username -p/--pasword --path]
-Username: <overleaf username>
-Password: <overleaf password>
+moritz@github:~/test$ ols login [--path]
 Login successful. Cookie persisted as `.olauth`. You may now sync your project.
 ```
 
-You can either specify your username and/or password on the command line or you will be prompted to enter them. The `login` command logs you into Overleaf and stores your *cookie* (**not** your login credentials) in a hidden file called `.olauth` in the same folder you run the command from. It is possible to store the cookie elsewhere using the `--path` option. The cookie file will not be synced to or from Overleaf.
+Logging in will be handled by a mini web browser opening on your device (using Qt5). You can then enter your username and password securely on the official Overleaf website. You might get asked to solve a CAPTCHA in the process. Your credentials are sent to Overleaf over HTTPS.
+
+It then stores your *cookie* (**not** your login credentials) in a hidden file called `.olauth` in the same folder you run the command from. It is possible to store the cookie elsewhere using the `--path` option. The cookie file will not be synced to or from Overleaf.
+
+Keep the `.olauth` file save, as it can be used to log in into your account.
 
 ### Syncing
 ```
 moritz@github:~/test$ ols [-l/--local-only -r/--remote-only --store-path -p/--path -i/--olignore]
 ```
 
-Just calling `ols` will two-way sync your project. When there are changes both locally and remotely you will be asked which file to keep. Using the `-l` or `-r` option you can specify to either sync local project files to Overleaf only or Overleaf files to local ones only respectively. The option `--store-path` specifies the path of the cookie file created by the `login` command. If you did not change its path you do not need to specify this argument. The `-p/--path` option allows you to specify a different sync folder than the one you're calling `ols` from. The `-i/--olignore` option allows you to specify the path of an `.olignore` file which works exactly like `.gitignore`.
+Just calling `ols` will two-way sync your project. When there are changes both locally and remotely you will be asked which file to keep. Using the `-l` or `-r` option you can specify to either sync local project files to Overleaf only or Overleaf files to local ones only respectively. The option `--store-path` specifies the path of the cookie file created by the `login` command. If you did not change its path, you do not need to specify this argument. The `-p/--path` option allows you to specify a different sync folder than the one you're calling `ols` from. The `-i/--olignore` option allows you to specify the path of an `.olignore` file which works exactly like `.gitignore`.
 
 Sample Output:
 
@@ -70,6 +73,10 @@ other-report.tex does not exist on local. Creating file.
 
 ## Known Bugs
 - When modifying a file on Overleaf and immediately syncing afterwards, the tool might not detect the changes. Please allow 1-2 minutes after modifying a file on Overleaf before syncing it to your local computer.
+
+## Contributing
+
+All pull requests and change/feature requests are welcome.
 
 ## Disclaimer
 THE AUTHOR OF THIS SOFTWARE AND THIS SOFTWARE IS NOT ENDORSED BY, DIRECTLY AFFILIATED WITH, MAINTAINED, AUTHORIZED, OR SPONSORED BY OVERLEAF OR WRITELATEX LIMITED. ALL PRODUCT AND COMPANY NAMES ARE THE REGISTERED TRADEMARKS OF THEIR ORIGINAL OWNERS. THE USE OF ANY TRADE NAME OR TRADEMARK IS FOR IDENTIFICATION AND REFERENCE PURPOSES ONLY AND DOES NOT IMPLY ANY ASSOCIATION WITH THE TRADEMARK HOLDER OF THEIR PRODUCT BRAND.

--- a/olsync/__init__.py
+++ b/olsync/__init__.py
@@ -1,3 +1,3 @@
 """Overleaf Two-Way Sync Tool"""
 
-__version__ = '1.1.4'
+__version__ = '1.1.5'

--- a/olsync/olbrowserlogin.py
+++ b/olsync/olbrowserlogin.py
@@ -6,7 +6,7 @@
 # Description: Overleaf Browser Login Utility
 # Author: Moritz Glöckl
 # License: MIT
-# Version: 1.1.4
+# Version: 1.1.5
 ##################################################
 
 from PyQt5.QtCore import *

--- a/olsync/olbrowserlogin.py
+++ b/olsync/olbrowserlogin.py
@@ -1,0 +1,93 @@
+"""Ol Browser Login Utility"""
+##################################################
+# MIT License
+##################################################
+# File: olbrowserlogin.py
+# Description: Overleaf Browser Login Utility
+# Author: Moritz Glöckl
+# License: MIT
+# Version: 1.1.4
+##################################################
+
+from PyQt5.QtCore import *
+from PyQt5.QtWidgets import *
+from PyQt5.QtWebEngineWidgets import *
+
+# Where to get the CSRF Token and where to send the login request to
+LOGIN_URL = "https://www.overleaf.com/login"
+PROJECT_URL = "https://www.overleaf.com/project"  # The dashboard URL
+# JS snippet to extract the csrfToken
+JAVASCRIPT_CSRF_EXTRACTOR = "document.getElementsByName('ol-csrfToken')[0].content"
+# Name of the cookies we want to extract
+COOKIE_NAMES = ["overleaf_session2", "GCLB"]
+
+
+class OlBrowserLoginWindow(QMainWindow):
+    """
+    Overleaf Browser Login Utility
+    Opens a browser window to securely login the user and returns relevant login data.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(OlBrowserLoginWindow, self).__init__(*args, **kwargs)
+
+        self.webview = QWebEngineView()
+
+        self._cookies = {}
+        self._csrf = ""
+        self._login_success = False
+
+        self.profile = QWebEngineProfile(self.webview)
+        self.cookie_store = self.profile.cookieStore()
+        self.cookie_store.cookieAdded.connect(self.handle_cookie_added)
+        self.profile.setPersistentCookiesPolicy(QWebEngineProfile.NoPersistentCookies)
+
+        self.profile.settings().setAttribute(QWebEngineSettings.JavascriptEnabled, True)
+
+        webpage = QWebEnginePage(self.profile, self)
+        self.webview.setPage(webpage)
+        self.webview.load(QUrl.fromUserInput(LOGIN_URL))
+        self.webview.loadFinished.connect(self.handle_load_finished)
+
+        self.setCentralWidget(self.webview)
+        self.resize(600, 700)
+
+    def handle_load_finished(self):
+        def callback(result):
+            self._csrf = result
+            self._login_success = True
+            QCoreApplication.quit()
+
+        if self.webview.url().toString() == PROJECT_URL:
+            self.webview.page().runJavaScript(
+                JAVASCRIPT_CSRF_EXTRACTOR, callback
+            )
+
+    def handle_cookie_added(self, cookie):
+        cookie_name = cookie.name().data().decode('utf-8')
+        if cookie_name in COOKIE_NAMES:
+            self._cookies[cookie_name] = cookie.value().data().decode('utf-8')
+
+    @property
+    def cookies(self):
+        return self._cookies
+
+    @property
+    def csrf(self):
+        return self._csrf
+
+    @property
+    def login_success(self):
+        return self._login_success
+
+
+def login():
+    app = QApplication([])
+    ol_browser_login_window = OlBrowserLoginWindow()
+    ol_browser_login_window.show()
+    app.exec()
+
+    if not ol_browser_login_window.login_success:
+        return None
+
+    return {"cookie": ol_browser_login_window.cookies, "csrf": ol_browser_login_window.csrf}

--- a/olsync/olclient.py
+++ b/olsync/olclient.py
@@ -47,6 +47,7 @@ class OverleafClient(object):
 
     def login(self, username, password):
         """
+        WARNING - DEPRECATED - Not working as Overleaf introduced captchas
         Login to the Overleaf Service with a username and a password
         Params: username, password
         Returns: Dict of cookie and CSRF
@@ -161,8 +162,8 @@ class OverleafClient(object):
         # Convert cookie from CookieJar to string
         cookie = "GCLB={}; overleaf_session2={}" \
             .format(
-            reqs.utils.dict_from_cookiejar(self._cookie)["GCLB"],
-            reqs.utils.dict_from_cookiejar(self._cookie)["overleaf_session2"]
+            self._cookie["GCLB"],
+            self._cookie["overleaf_session2"]
         )
 
         # Connect to Overleaf Socket.IO, send a time parameter and the cookies

--- a/olsync/olclient.py
+++ b/olsync/olclient.py
@@ -6,7 +6,7 @@
 # Description: Overleaf API Wrapper
 # Author: Moritz Glöckl
 # License: MIT
-# Version: 1.1.4
+# Version: 1.1.5
 ##################################################
 
 import requests as reqs

--- a/olsync/olsync.py
+++ b/olsync/olsync.py
@@ -6,7 +6,7 @@
 # Description: Overleaf Two-Way Sync
 # Author: Moritz Glöckl
 # License: MIT
-# Version: 1.1.4
+# Version: 1.1.5
 ##################################################
 
 import click

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,19 @@ author-email = "moritzgloeckl@users.noreply.github.com"
 home-page = "https://github.com/moritzgloeckl/overleaf-sync"
 classifiers = ["License :: OSI Approved :: MIT License", "Intended Audience :: Science/Research", "Programming Language :: Python :: 3"]
 requires-python = ">=3"
-requires = ["requests", "beautifulsoup4", "yaspin", "python-dateutil", "click", "socketIO-client == 0.5.7.2"]
+requires = [
+    "requests",
+    "beautifulsoup4",
+    "yaspin",
+    "python-dateutil",
+    "click",
+    "socketIO-client == 0.5.7.2",
+    "PyQt5",
+    "PyQt5-Qt5",
+    "PyQt5-sip",
+    "PyQtWebEngine",
+    "PyQtWebEngine-Qt5"
+]
 keywords = "overleaf sync latex tex"
 
 [tool.flit.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,11 @@
-requests
-beautifulsoup4
-yaspin
-python-dateutil
-click
+requests~=2.25.1
+beautifulsoup4~=4.9.3
+yaspin~=2.0.0
+python-dateutil~=2.8.1
+click~=8.0.1
 socketIO-client == 0.5.7.2
+PyQt5~=5.15.4
+PyQt5-Qt5~=5.15.2
+PyQt5-sip~=12.9.0
+PyQtWebEngine~=5.15.4
+PyQtWebEngine-Qt5~=5.15.2


### PR DESCRIPTION
This PR updates the login flow, so that the newly introduced changes by Overleaf (namely integrating reCaptcha) can be overcome. Login doesn't work in command line anymore, rather it opens a browser window with the official login page, lets the user login and extracts the relevant data from this window. 