### PR TITLE
Fix unexpected keyword argument with click dependency #31 #35

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ requires = [
     "beautifulsoup4",
     "yaspin",
     "python-dateutil",
-    "click",
+    "click == 8.0.1",
     "socketIO-client == 0.5.7.2",
     "PyQt5",
     "PyQt5-Qt5",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ requests~=2.25.1
 beautifulsoup4~=4.9.3
 yaspin~=2.0.0
 python-dateutil~=2.8.1
-click~=8.0.1
+click == 8.0.1
 socketIO-client == 0.5.7.2
 PyQt5~=5.15.4
 PyQt5-Qt5~=5.15.2


### PR DESCRIPTION
Fix errors some people encountered when installing `overleaf-sync`. The problem is related to the click package, if version `8.0.1` is not installed it leads to the error in #31 and #35.