### PR TITLE
Add list verb for listing all projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,17 @@ It then stores your *cookie* (**not** your login credentials) in a hidden file c
 
 Keep the `.olauth` file save, as it can be used to log in into your account.
 
+### Listing all projects
+```
+moritz@github:~/test$ ols list [--store-path -v/--verbose]
+10/31/2021, 01:23:45 - Project A
+09/21/2020, 01:23:45 - Project B
+08/11/2019, 01:23:45 - Project C
+07/01/2018, 01:23:45 - Project D
+```
+
+Use `ols list` to conveniently list all projects in your account available for syncing. 
+
 ### Syncing
 ```
 moritz@github:~/test$ ols [-l/--local-only -r/--remote-only --store-path -p/--path -i/--olignore]

--- a/olsync/olsync.py
+++ b/olsync/olsync.py
@@ -34,7 +34,6 @@ except ImportError:
 @click.option('-l', '--local-only', 'local', is_flag=True, help="Sync local project files to Overleaf only.")
 @click.option('-r', '--remote-only', 'remote', is_flag=True,
               help="Sync remote project files from Overleaf to local file system only.")
-@click.option('-L', '--list', 'list_projects', is_flag=True, help="List all projects.")
 @click.option('-n', '--name', 'project_name', default="",
               help="Specify the Overleaf project name instead of the default name of the sync directory.")
 @click.option('--store-path', 'cookie_path', default=".olauth", type=click.Path(exists=False),
@@ -46,7 +45,7 @@ except ImportError:
 @click.option('-v', '--verbose', 'verbose', is_flag=True, help="Enable extended error logging.")
 @click.version_option(package_name='overleaf-sync')
 @click.pass_context
-def main(ctx, local, remote, list_projects, project_name, cookie_path, sync_path, olignore_path, verbose):
+def main(ctx, local, remote, project_name, cookie_path, sync_path, olignore_path, verbose):
     if ctx.invoked_subcommand is None:
         if not os.path.isfile(cookie_path):
             raise click.ClickException(
@@ -59,11 +58,6 @@ def main(ctx, local, remote, list_projects, project_name, cookie_path, sync_path
 
         # Change the current directory to the specified sync path
         os.chdir(sync_path)
-
-        if list_projects:
-            for p in sorted(overleaf_client.all_projects(), key=lambda x: x['lastUpdated'], reverse=True):
-                print(p['lastUpdated'], p['name'])
-            return
 
         project_name = project_name or os.path.basename(os.getcwd())
         project = execute_action(
@@ -128,6 +122,33 @@ def login(cookie_path, verbose):
                    "Login successful. Cookie persisted as `" + click.format_filename(
                        cookie_path) + "`. You may now sync your project.",
                    "Login failed. Please try again.", verbose)
+
+
+@main.command(name='list')
+@click.option('--store-path', 'cookie_path', default=".olauth", type=click.Path(exists=False),
+              help="Relative path to load the persisted Overleaf cookie.")
+@click.option('-v', '--verbose', 'verbose', is_flag=True, help="Enable extended error logging.")
+def list_projects(cookie_path, verbose):
+    def query_projects():
+        for index, p in enumerate(sorted(overleaf_client.all_projects(), key=lambda x: x['lastUpdated'], reverse=True)):
+            if not index:
+                click.echo("\n")
+            click.echo(f"{dateutil.parser.isoparse(p['lastUpdated']).strftime('%m/%d/%Y, %H:%M:%S')} - {p['name']}")
+        return True
+
+    if not os.path.isfile(cookie_path):
+        raise click.ClickException(
+            "Persisted Overleaf cookie not found. Please login or check store path.")
+
+    with open(cookie_path, 'rb') as f:
+        store = pickle.load(f)
+
+    overleaf_client = OverleafClient(store["cookie"], store["csrf"])
+
+    click.clear()
+    execute_action(query_projects, "Querying all projects",
+                   "Querying all projects successful.",
+                   "Querying all projects failed. Please try again.", verbose)
 
 
 def login_handler(path):

--- a/olsync/olsync.py
+++ b/olsync/olsync.py
@@ -34,6 +34,7 @@ except ImportError:
 @click.option('-l', '--local-only', 'local', is_flag=True, help="Sync local project files to Overleaf only.")
 @click.option('-r', '--remote-only', 'remote', is_flag=True,
               help="Sync remote project files from Overleaf to local file system only.")
+@click.option('-L', '--list', 'list_projects', is_flag=True, help="List all projects.")
 @click.option('-n', '--name', 'project_name', default="",
               help="Specify the Overleaf project name instead of the default name of the sync directory.")
 @click.option('--store-path', 'cookie_path', default=".olauth", type=click.Path(exists=False),
@@ -45,7 +46,7 @@ except ImportError:
 @click.option('-v', '--verbose', 'verbose', is_flag=True, help="Enable extended error logging.")
 @click.version_option(package_name='overleaf-sync')
 @click.pass_context
-def main(ctx, local, remote, project_name, cookie_path, sync_path, olignore_path, verbose):
+def main(ctx, local, remote, list_projects, project_name, cookie_path, sync_path, olignore_path, verbose):
     if ctx.invoked_subcommand is None:
         if not os.path.isfile(cookie_path):
             raise click.ClickException(
@@ -58,6 +59,11 @@ def main(ctx, local, remote, project_name, cookie_path, sync_path, olignore_path
 
         # Change the current directory to the specified sync path
         os.chdir(sync_path)
+
+        if list_projects:
+            for p in sorted(overleaf_client.all_projects(), key=lambda x: x['lastUpdated'], reverse=True):
+                print(p['lastUpdated'], p['name'])
+            return
 
         project_name = project_name or os.path.basename(os.getcwd())
         project = execute_action(


### PR DESCRIPTION
I've modified @zzjjzzgggg to have -L as a separate verb so users can call `ols list` instead of `ols -L`. I liked this option more so that it is separated from the syncing done by calling `ols`.