### PR TITLE
Mark spinner as failed before raising exception

### DIFF
--- a/olsync/olsync.py
+++ b/olsync/olsync.py
@@ -248,8 +248,8 @@ def execute_action(action, progress_message, success_message, fail_message, verb
             spinner.write(success_message)
             spinner.ok("✅ ")
         else:
-            raise click.ClickException(fail_message)
             spinner.fail("💥 ")
+            raise click.ClickException(fail_message)
 
         return success
 


### PR DESCRIPTION
I didn't test this yet, but when I browsed the original code, `pylint` showed me the _Code unreachable_ warning for the `spinner.fail("💥 ")`, since it happens after an exception is raised and if it is like other exceptions, it exists the program.