### PR TITLE
Add support for Community Edition server

### DIFF
--- a/olsync/olbrowserlogin.py
+++ b/olsync/olbrowserlogin.py
@@ -14,14 +14,9 @@ from PySide6.QtWidgets import *
 from PySide6.QtWebEngineWidgets import *
 from PySide6.QtWebEngineCore import QWebEngineProfile, QWebEngineSettings, QWebEnginePage
 
-# Where to get the CSRF Token and where to send the login request to
-LOGIN_URL = "https://www.overleaf.com/login"
-PROJECT_URL = "https://www.overleaf.com/project"  # The dashboard URL
+
 # JS snippet to extract the csrfToken
 JAVASCRIPT_CSRF_EXTRACTOR = "document.getElementsByName('ol-csrfToken')[0].content"
-# Name of the cookies we want to extract
-COOKIE_NAMES = ["overleaf_session2", "GCLB"]
-
 
 class OlBrowserLoginWindow(QMainWindow):
     """
@@ -29,8 +24,18 @@ class OlBrowserLoginWindow(QMainWindow):
     Opens a browser window to securely login the user and returns relevant login data.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, ce_url=None, *args, **kwargs):
         super(OlBrowserLoginWindow, self).__init__(*args, **kwargs)
+
+        if ce_url is not None:
+            self._BASE_URL = ce_url
+            self._cookies_names = ["sharelatex.sid"]
+        else:
+            self._BASE_URL = "https://www.overleaf.com"  # The Overleaf Base URL
+            self._cookies_names = ["overleaf_session2", "GCLB"]
+
+        self._LOGIN_URL = f"{self._BASE_URL}/login"
+        self._PROJECT_URL = f"{self._BASE_URL}/project"
 
         self.webview = QWebEngineView()
 
@@ -47,7 +52,7 @@ class OlBrowserLoginWindow(QMainWindow):
 
         webpage = QWebEnginePage(self.profile, self)
         self.webview.setPage(webpage)
-        self.webview.load(QUrl.fromUserInput(LOGIN_URL))
+        self.webview.load(QUrl.fromUserInput(self._LOGIN_URL))
         self.webview.loadFinished.connect(self.handle_load_finished)
 
         self.setCentralWidget(self.webview)
@@ -59,14 +64,14 @@ class OlBrowserLoginWindow(QMainWindow):
             self._login_success = True
             QCoreApplication.quit()
 
-        if self.webview.url().toString() == PROJECT_URL:
+        if self.webview.url().toString() == self._PROJECT_URL:
             self.webview.page().runJavaScript(
                 JAVASCRIPT_CSRF_EXTRACTOR, 0, callback
             )
 
     def handle_cookie_added(self, cookie):
         cookie_name = cookie.name().data().decode('utf-8')
-        if cookie_name in COOKIE_NAMES:
+        if cookie_name in self._cookies_names:
             self._cookies[cookie_name] = cookie.value().data().decode('utf-8')
 
     @property
@@ -82,14 +87,14 @@ class OlBrowserLoginWindow(QMainWindow):
         return self._login_success
 
 
-def login():
+def login(ce_url=None):
     from PySide6.QtCore import QLoggingCategory
     QLoggingCategory.setFilterRules('''\
     qt.webenginecontext.info=false
     ''')
 
     app = QApplication([])
-    ol_browser_login_window = OlBrowserLoginWindow()
+    ol_browser_login_window = OlBrowserLoginWindow(ce_url)
     ol_browser_login_window.show()
     app.exec()
 

--- a/olsync/olclient.py
+++ b/olsync/olclient.py
@@ -16,17 +16,8 @@ import uuid
 from socketIO_client import SocketIO
 import time
 
-# Where to get the CSRF Token and where to send the login request to
-LOGIN_URL = "https://www.overleaf.com/login"
-PROJECT_URL = "https://www.overleaf.com/project"  # The dashboard URL
-# The URL to download all the files in zip format
-DOWNLOAD_URL = "https://www.overleaf.com/project/{}/download/zip"
-UPLOAD_URL = "https://www.overleaf.com/project/{}/upload"  # The URL to upload files
-FOLDER_URL = "https://www.overleaf.com/project/{}/folder"  # The URL to create folders
-DELETE_URL = "https://www.overleaf.com/project/{}/doc/{}"  # The URL to delete files
-COMPILE_URL = "https://www.overleaf.com/project/{}/compile?enable_pdf_caching=true"  # The URL to compile the project
-BASE_URL = "https://www.overleaf.com"  # The Overleaf Base URL
 PATH_SEP = "/"  # Use hardcoded path separator for both windows and posix system
+
 
 class OverleafClient(object):
     """
@@ -43,9 +34,25 @@ class OverleafClient(object):
                 if all(p.get(k) == v for k, v in more_attrs.items()):
                     yield p
 
-    def __init__(self, cookie=None, csrf=None):
+    def __init__(self, cookie=None, csrf=None, ce_url=None):
         self._cookie = cookie  # Store the cookie for authenticated requests
         self._csrf = csrf  # Store the CSRF token since it is needed for some requests
+        # Where to get the CSRF Token and where to send the login request to
+        if ce_url is not None:
+            self._ce = True
+            self._BASE_URL = ce_url
+        else:
+            self._BASE_URL = "https://www.overleaf.com"  # The Overleaf Base URL
+            self._ce = True
+
+        self._LOGIN_URL = self._BASE_URL + "/login"
+        self._PROJECT_URL = self._BASE_URL + "/project"  # The dashboard URL
+        # The URL to download all the files in zip format
+        self._DOWNLOAD_URL = self._BASE_URL + "/project/{}/download/zip"
+        self._UPLOAD_URL = self._BASE_URL + "/project/{}/upload"  # The URL to upload files
+        self._FOLDER_URL = self._BASE_URL + "/project/{}/folder"  # The URL to create folders
+        self._COMPILE_URL = self._BASE_URL + "/project/{}/compile?enable_pdf_caching=true"  # The URL to compile the project
+        self._DELETE_URL = self._BASE_URL + "/project/{}/doc/{}"  # The URL to delete files
 
     def login(self, username, password):
         """
@@ -55,7 +62,7 @@ class OverleafClient(object):
         Returns: Dict of cookie and CSRF
         """
 
-        get_login = reqs.get(LOGIN_URL)
+        get_login = reqs.get(self._LOGIN_URL)
         self._csrf = BeautifulSoup(get_login.content, 'html.parser').find(
             'input', {'name': '_csrf'}).get('value')
         login_json = {
@@ -63,20 +70,22 @@ class OverleafClient(object):
             "email": username,
             "password": password
         }
-        post_login = reqs.post(LOGIN_URL, json=login_json,
+        post_login = reqs.post(self._LOGIN_URL, json=login_json,
                                cookies=get_login.cookies)
 
         # On a successful authentication the Overleaf API returns a new authenticated cookie.
         # If the cookie is different than the cookie of the GET request the authentication was successful
-        if post_login.status_code == 200 and get_login.cookies["overleaf_session2"] != post_login.cookies[
-            "overleaf_session2"]:
+        if post_login.status_code == 200 and ((self._ce and get_login.cookies["sharelatex.sid"] != post_login.cookies[
+            "sharelatex.sid"]) or get_login.cookies["overleaf_session2"] != post_login.cookies[
+                                                  "overleaf_session2"]):
             self._cookie = post_login.cookies
 
             # Enrich cookie with GCLB cookie from GET request above
-            self._cookie['GCLB'] = get_login.cookies['GCLB']
+            if not self._ce:
+                self._cookie['GCLB'] = get_login.cookies['GCLB']
 
             # CSRF changes after making the login request, new CSRF token will be on the projects page
-            projects_page = reqs.get(PROJECT_URL, cookies=self._cookie)
+            projects_page = reqs.get(self._PROJECT_URL, cookies=self._cookie)
             self._csrf = BeautifulSoup(projects_page.content, 'html.parser').find('meta', {'name': 'ol-csrfToken'}) \
                 .get('content')
 
@@ -87,7 +96,7 @@ class OverleafClient(object):
         Get all of a user's active projects (= not archived and not trashed)
         Returns: List of project objects
         """
-        projects_page = reqs.get(PROJECT_URL, cookies=self._cookie)
+        projects_page = reqs.get(self._PROJECT_URL, cookies=self._cookie)
         json_content = json.loads(
             BeautifulSoup(projects_page.content, 'html.parser').find('meta', {'name': 'ol-projects'}).get('content'))
         return list(OverleafClient.filter_projects(json_content))
@@ -99,7 +108,7 @@ class OverleafClient(object):
         Returns: project object
         """
 
-        projects_page = reqs.get(PROJECT_URL, cookies=self._cookie)
+        projects_page = reqs.get(self._PROJECT_URL, cookies=self._cookie)
         json_content = json.loads(
             BeautifulSoup(projects_page.content, 'html.parser').find('meta', {'name': 'ol-projects'}).get('content'))
         return next(OverleafClient.filter_projects(json_content, {"name": project_name}), None)
@@ -110,7 +119,7 @@ class OverleafClient(object):
         Params: project_id, the id of the project
         Returns: bytes string (zip file)
         """
-        r = reqs.get(DOWNLOAD_URL.format(project_id),
+        r = reqs.get(self._DOWNLOAD_URL.format(project_id),
                      stream=True, cookies=self._cookie)
         return r.content
 
@@ -133,7 +142,7 @@ class OverleafClient(object):
         headers = {
             "X-Csrf-Token": self._csrf
         }
-        r = reqs.post(FOLDER_URL.format(project_id),
+        r = reqs.post(self._FOLDER_URL.format(project_id),
                       cookies=self._cookie, headers=headers, json=params)
 
         if r.ok:
@@ -162,15 +171,12 @@ class OverleafClient(object):
             project_infos = project_infos_dict
 
         # Convert cookie from CookieJar to string
-        cookie = "GCLB={}; overleaf_session2={}" \
-            .format(
-            self._cookie["GCLB"],
-            self._cookie["overleaf_session2"]
-        )
+        cookie = f"GCLB={self._cookie['GCLB']}; overleaf_session2={self._cookie['overleaf_session2']}" if not self._ce \
+            else f"sharelatex.sid={self._cookie['sharelatex.sid']}"
 
         # Connect to Overleaf Socket.IO, send a time parameter and the cookies
         socket_io = SocketIO(
-            BASE_URL,
+            self._BASE_URL,
             params={'t': int(time.time())},
             headers={'Cookie': cookie}
         )
@@ -237,7 +243,7 @@ class OverleafClient(object):
         }
 
         # Upload the file to the predefined folder
-        r = reqs.post(UPLOAD_URL.format(project_id), cookies=self._cookie, params=params, files=files)
+        r = reqs.post(self._UPLOAD_URL.format(project_id), cookies=self._cookie, params=params, files=files)
 
         return r.status_code == str(200) and json.loads(r.content)["success"]
 
@@ -278,7 +284,8 @@ class OverleafClient(object):
             "X-Csrf-Token": self._csrf
         }
 
-        r = reqs.delete(DELETE_URL.format(project_id, file['_id']), cookies=self._cookie, headers=headers, json={})
+        r = reqs.delete(self._DELETE_URL.format(project_id, file['_id']), cookies=self._cookie, headers=headers,
+                        json={})
 
         return r.status_code == str(204)
 
@@ -303,7 +310,7 @@ class OverleafClient(object):
             "stopOnFirstError": False
         }
 
-        r = reqs.post(COMPILE_URL.format(project_id), cookies=self._cookie, headers=headers, json=body)
+        r = reqs.post(self._COMPILE_URL.format(project_id), cookies=self._cookie, headers=headers, json=body)
 
         if not r.ok:
             raise reqs.HTTPError()
@@ -315,7 +322,7 @@ class OverleafClient(object):
 
         pdf_file = next(v for v in compile_result['outputFiles'] if v['type'] == 'pdf')
 
-        download_req = reqs.get(BASE_URL + pdf_file['url'], cookies=self._cookie, headers=headers)
+        download_req = reqs.get(self._BASE_URL + pdf_file['url'], cookies=self._cookie, headers=headers)
 
         if download_req.ok:
             return pdf_file['path'], download_req.content


### PR DESCRIPTION
I have made a new PR to Community Edition support building on the great work of @hrvylein in #17, and updating the PR to support `overleaf-sync` `1.2` login flow.

The community Edition url is either from the `--ce-url` argument or from an `.olce` file

@moritzgloeckl for testing the PR you can consider setting up a local overleaf server using docker https://github.com/overleaf/overleaf#overleaf-docker-image otherwise I can also create an instance of overleaf on my server, so that you can access it and test it.

P.S. @moritzgloeckl thanks a lot for this tool, is very convenient!